### PR TITLE
FAQ Page: Fix div inside p error

### DIFF
--- a/src/pages/FAQ.js
+++ b/src/pages/FAQ.js
@@ -12,13 +12,9 @@ import {
 } from "@chakra-ui/react";
 
 //assets
-import { navigate } from "gatsby";
-import { useBreakpoint } from "gatsby-plugin-breakpoints";
 import { Box } from "@chakra-ui/layout";
 
-const FAQ = (props) => {
-  const matches = useBreakpoint();
-
+const FAQ = () => {
   return (
     <>
       <Metadata
@@ -118,7 +114,8 @@ const FAQ = (props) => {
                   These tokens are unique forever. The minting policy is time
                   based and closed on the 22nd of August 2021.
                   <br /> The minting script:
-                  <Box fontWeight="medium" my={4}>
+                  <br />
+                  <br />
                     {`{
                     type: "all",
                     scripts: [
@@ -130,7 +127,8 @@ const FAQ = (props) => {
                       }
                     ]
                   }`}
-                  </Box>
+                  <br />
+                  <br />
                   Hash it and you get the following Policy ID:
                   <br />
                   <Link


### PR DESCRIPTION
When you navigate the FAQ page you get the following warning: 

```
react-dom.development.js:88 Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
```

This is because of the `<Box>` component inside one of the FAQs. I took that out and managed the spacing with `<br>`s instead. 

Managing spacing with `<br>`s isn't as good as using `<p>`'s, but this probably isn't your #1 priority and it gets the job done. :) 

Here's how it looks now: 

<img width="1054" alt="Screen Shot 2021-10-26 at 7 10 18 PM" src="https://user-images.githubusercontent.com/3202211/138987961-a9378d7a-5565-4afb-acfa-c9e190ad4109.png">
