### PR TITLE
Spacebud - Give gadgets unique keys

### DIFF
--- a/src/templates/spacebud.js
+++ b/src/templates/spacebud.js
@@ -793,10 +793,9 @@ const SpaceBud = ({ pageContext: { spacebud } }) => {
             }}
           >
             {spacebud.gadgets.length > 0 ? (
-              spacebud.gadgets.map((gadget, index) => (
-                <Box p="1">
+              spacebud.gadgets.map((gadget) => (
+                <Box key={gadget} p="1">
                   <Attribute
-                    key={index}
                     onClick={() => navigate(`/explore/?gadget=${gadget}`)}
                   >
                     {gadget}


### PR DESCRIPTION
When visiting a Spacebud, you get the following warning: 
```
react.development.js:315 Warning: Each child in a list should have a unique "key" prop.
```

Rather than using the `index` as the key, I just used the `gadget` since they'd be unique. 